### PR TITLE
Improve logging on readyz and requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple Django CRUD API for tasks. Includes health and readiness endpoints.
 
 ## Development
 
-Install dependencies (Django and other packages are pinned in
+Install dependencies (Django, Gunicorn and other packages are pinned in
 `requirements.txt`) and run migrations:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Simple Django CRUD API for tasks. Includes health and readiness endpoints.
 
 ## Development
 
-Install dependencies and run migrations:
+Install dependencies (Django and other packages are pinned in
+`requirements.txt`) and run migrations:
 
 ```bash
 make install

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework==3.16.0
 psycopg2-binary==2.9.10
 pytest==8.3.5
 pytest-django==4.11.1
+gunicorn>=20.1.0

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -1,15 +1,38 @@
+import logging
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from django.http import HttpResponse
 from django.db import connections
 from django.db.utils import OperationalError
+
+logger = logging.getLogger(__name__)
 from .models import Task
 from .serializers import TaskSerializer
 
 class TaskViewSet(viewsets.ModelViewSet):
     queryset = Task.objects.all().order_by('-created_at')
     serializer_class = TaskSerializer
+
+    def list(self, request, *args, **kwargs):
+        logger.info("List tasks called", extra={"params": request.query_params.dict()})
+        return super().list(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        logger.info("Retrieve task", extra={"task_id": kwargs.get('pk')})
+        return super().retrieve(request, *args, **kwargs)
+
+    def create(self, request, *args, **kwargs):
+        logger.info("Create task", extra={"data": request.data})
+        return super().create(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        logger.info("Update task", extra={"task_id": kwargs.get('pk'), "data": request.data})
+        return super().update(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        logger.info("Delete task", extra={"task_id": kwargs.get('pk')})
+        return super().destroy(request, *args, **kwargs)
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -30,8 +53,11 @@ def healthz(request):
 
 @api_view(['GET'])
 def readyz(request):
+    logger.info("Readyz check called - verifying database connection")
     try:
         connections['default'].cursor()
+        logger.info("Database connection successful")
         return Response({'status': 'ok'})
     except OperationalError:
+        logger.exception("Database connection failed")
         return Response({'status': 'error'}, status=500)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,3 +8,11 @@ def test_healthz():
     resp = client.get('/healthz')
     assert resp.status_code == 200
     assert resp.text == 'alive'
+
+
+@pytest.mark.django_db
+def test_readyz():
+    client = APIClient()
+    resp = client.get('/readyz')
+    assert resp.status_code == 200
+    assert resp.json()['status'] == 'ok'


### PR DESCRIPTION
## Summary
- add DB connection and request logging
- test readyz endpoint

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_684484b28c248329a34dcb4bda538367